### PR TITLE
Hotfix v3.1.1: Catch socket.timeout to fix Error reading SSH protocol banner

### DIFF
--- a/rsync_to_rdisc.py
+++ b/rsync_to_rdisc.py
@@ -143,13 +143,16 @@ def connect_to_remote_server(host_keys, server, user, run_file):
     try:
         client.connect(server[0], username=user)
         hpc_server = server[0]
-    except OSError:
+    except (OSError, socket.timeout):
         try:
             client.connect(server[1], username=user)
             hpc_server = server[1]
         except OSError:
             make_mail(" and ".join(server), "lost_hpc", run_file=run_file)
             sys.exit("connection to HPC transfernodes are lost")
+        except socket.timeout:
+            sys.exit("HPC connection timeout")
+            os.remove(run_file)
 
     return client, hpc_server
 


### PR DESCRIPTION
Catch socket.timeout based on: https://pythonhosted.org/theape/documentation/developer/explorations/explore_paramiko/exploring_errors.html#paramiko-socket-timeout

Information about SSH protocol banner:
> This happens if the server accepts the connection but the ssh daemon doesn't respond within 15 seconds. It could be network congestion, faulty switches, etc... but usually it means that the target server is bogged down or its sshd has hung. Recovery is to wait and try again.

Therefor, we catch the error, try the other hpc transfer server and if that does not remove run file and try again in 15 minutes (daemon interval). 