### PR TITLE
Feature/add error transferred runs

### DIFF
--- a/.github/workflows/rsync_to_rdisc.yml
+++ b/.github/workflows/rsync_to_rdisc.yml
@@ -1,0 +1,45 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: rsync_to_rdisc
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.6"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        # use dev requirements including pytest and flake8
+        if [ -f requirements/dev.txt ]; then pip install -r requirements/dev.txt; fi  
+        pip install -e .
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest --cov --cov-report=html --cov-report=term test_rsync_to_rdisc.py

--- a/.gitignore
+++ b/.gitignore
@@ -132,7 +132,7 @@ dmypy.json
 .DS_Store
 */.DS_Store
 
-
+# VSCode 
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,16 @@ dmypy.json
 .DS_Store
 */.DS_Store
 
+
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-paramiko==2.10.4
-Jinja2==3.0.3
-cryptography==36.0.2
+# Mirrors prod
+-r requirements/prod.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,7 @@
+# Mirror production requirements
+-r prod.txt
+# Add dev specific packages
+pytest==7.4.2
+pytest-cov==4.1.0
+pytest-mock==3.11.1
+pytest-raises==0.11

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,0 +1,3 @@
+paramiko==2.10.4
+Jinja2==3.0.3
+cryptography==36.0.2

--- a/rsync_to_rdisc.py
+++ b/rsync_to_rdisc.py
@@ -282,14 +282,14 @@ def rsync_server_remote(settings, hpc_server, client, to_be_transferred):
 
 def run_vcf_upload(vcf_file, vcf_type, run):
     upload_vcf = subprocess.run(
-            (
-                f"source {settings.alissa_vcf_upload}/venv/bin/activate && "
-                f"python {settings.alissa_vcf_upload}/vcf_upload.py {vcf_file} '{vcf_type}' {run}"
-            ),
-            shell=True,
-            stdout=subprocess.PIPE,
-            encoding='UTF-8'
-        )
+        (
+            f"source {settings.alissa_vcf_upload}/venv/bin/activate && "
+            f"python {settings.alissa_vcf_upload}/vcf_upload.py {vcf_file} '{vcf_type}' {run}"
+        ),
+        shell=True,
+        stdout=subprocess.PIPE,
+        encoding='UTF-8'
+    )
     # Cleanup upload_vcf output: Strip and split on new line, remove empty strings from list
     upload_vcf_out = list(filter(None, upload_vcf.stdout.strip().split('\n')))
     return upload_vcf_out

--- a/rsync_to_rdisc.py
+++ b/rsync_to_rdisc.py
@@ -355,23 +355,23 @@ def upload_exomedepth_vcf(run, run_folder):
 
 if __name__ == "__main__":
 
-    """ If daemon is running exit, else create transfer.running file and continue """
+    """If daemon is running exit, else create transfer.running file and continue."""
     run_file = check_daemon_running(settings.wkdir)
 
-    """ Check if mount to BGarray intact """
+    """Check if mount to BGarray intact."""
     check_mount(settings.bgarray, run_file)
 
     """ Make dictionairy of transferred_runs.txt file, or create transferred_runs.txt if not present """
     transferred_dic = make_dictionary_runs(settings.wkdir)
 
-    """ Get folders to be transfer from HPC """
+    """Get folders to be transfer from HPC."""
     client, hpc_server = connect_to_remote_server(settings.host_keys, settings.server, settings.user, run_file)
     to_be_transferred = get_folders_remote_server(client, settings.folder_dic, run_file)
 
     """Rsync folders from HPC to bgarray"""
     remove_run_file = rsync_server_remote(settings, hpc_server, client, to_be_transferred)
 
-    """ Remove run_file if transfer daemon shouldn't be blocked to prevent repeated mailing """
+    """Remove run_file if transfer daemon shouldn't be blocked to prevent repeated mailing."""
     if remove_run_file:
         os.remove(run_file)
 

--- a/rsync_to_rdisc.py
+++ b/rsync_to_rdisc.py
@@ -126,17 +126,15 @@ def check_mount(bgarray, run_file):
         sys.exit()
 
 
-def make_dictionary_runs(wkdir):
-    transferred_dic = {}
-    if os.path.isfile(str(wkdir) + "transferred_runs.txt"):
-        with open("{}/transferred_runs.txt".format(wkdir), 'r') as runs:
-            for line in runs:
-                transferred_dic[line.rstrip()] = ""
+def get_transferred_runs(wkdir):
+    transferred_runs = Path(f"{wkdir}/transferred_runs.txt")
+    if transferred_runs.is_file():
+        with open(transferred_runs, 'r') as runs:
+            transferred_set = set(runs.read().splitlines())
+        return transferred_set
     else:
-        new_file = open(str(wkdir) + "transferred_runs.txt", "w")
-        new_file.close()
-
-    return transferred_dic
+        Path.touch(transferred_runs)
+        return {}
 
 
 def connect_to_remote_server(host_keys, server, user, run_file):
@@ -361,8 +359,8 @@ if __name__ == "__main__":
     """Check if mount to BGarray intact."""
     check_mount(settings.bgarray, run_file)
 
-    """ Make dictionairy of transferred_runs.txt file, or create transferred_runs.txt if not present """
-    transferred_dic = make_dictionary_runs(settings.wkdir)
+    """Make set of transferred_runs.txt file, or create transferred_runs.txt if not present."""
+    transferred_set = get_transferred_runs(settings.wkdir)
 
     """Get folders to be transfer from HPC."""
     client, hpc_server = connect_to_remote_server(settings.host_keys, settings.server, settings.user, run_file)

--- a/rsync_to_rdisc.py
+++ b/rsync_to_rdisc.py
@@ -110,19 +110,15 @@ def rsync_and_check(action, run, folder, temperror, wkdir, folder_dic, log):
 
 
 def check_daemon_running(wkdir):
-    run_file = "{}/transfer.running".format(wkdir)
-    if os.path.isfile(run_file):
+    try:
+        Path(f"{wkdir}/transfer.running").touch(exist_ok=False)
+    except FileExistsError:
         sys.exit()
-    else:
-        os.system("touch {}".format(run_file))
-        return run_file
 
 
 def check_mount(bgarray, run_file):
-    if os.path.exists(bgarray):
-        pass
-    else:
-        make_mail("mount", "lost_mount", run_file=run_file)
+    if not Path(bgarray).exists():
+        send_mail_lost_mount("mount", "lost_mount", run_file=run_file)
         sys.exit()
 
 

--- a/rsync_to_rdisc.py
+++ b/rsync_to_rdisc.py
@@ -178,14 +178,14 @@ def get_folders_remote_server(client, folder_dic, run_file):
     return to_be_transferred
 
 
-def check_if_file_missing(folder, client, run):
+def check_if_file_missing(required_files, input_folder, client):
     missing = []
-    for check_file in folder["files_required"]:
+    for check_file in required_files:
         if check_file:
             stdin, stdout, stderr = client.exec_command((
-                "[[ -f {0}{1}/{2} ]] && echo \"Present\" "
+                "[[ -f {0}/{1} ]] && echo \"Present\" "
                 "|| echo \"Absent\""
-            ).format(folder["input"], run, check_file))
+            ).format(input_folder, check_file))
             status = stdout.read().decode("utf8").rstrip()
             if status == "Absent":
                 missing.append(check_file)

--- a/rsync_to_rdisc.py
+++ b/rsync_to_rdisc.py
@@ -184,7 +184,9 @@ def action_if_file_missing(folder, remove_run_file, missing, run, folder_locatio
         return False
 
 
-def rsync_server_remote(hpc_server, client, to_be_transferred, run_file, log=settings.log, bgarray=settings.bgarray, wkdir=settings.wkdir):
+def rsync_server_remote(
+        hpc_server, client, to_be_transferred, run_file, log=settings.log, bgarray=settings.bgarray, wkdir=settings.wkdir
+):
     date = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     remove_run_file = True
 

--- a/rsync_to_rdisc.py
+++ b/rsync_to_rdisc.py
@@ -349,6 +349,6 @@ if __name__ == "__main__":
 
     """Remove run_file if transfer daemon shouldn't be blocked to prevent repeated mailing."""
     if remove_run_file:
-        os.remove(run_file)
+        Path.unlink(run_file)
 
     client.close()

--- a/rsync_to_rdisc.py
+++ b/rsync_to_rdisc.py
@@ -184,16 +184,14 @@ def action_if_file_missing(folder, remove_run_file, missing, run, folder_locatio
         return False
 
 
-def rsync_server_remote(hpc_server, client, to_be_transferred, run_file):
-    date = datetime.now.strftime("%Y-%m-%d %H:%M:%S")
+def rsync_server_remote(hpc_server, client, to_be_transferred, run_file, log=settings.log, bgarray=settings.bgarray, wkdir=settings.wkdir):
+    date = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     remove_run_file = True
 
     temperror = settings.temperror
     folder_dic = settings.folder_dic
-    log = settings.log
-
     for run in to_be_transferred:
-        with open(f"{settings.bgarray}/{log}", 'a', newline='\n') as log_file:
+        with open(f"{bgarray}/{log}", 'a', newline='\n') as log_file:
             log_file_writer = writer(log_file, delimiter='\t')
             log_file_writer.writerows([["#########"], [f"Date: {date}", f"Run_folder: {run}"]])
         folder_location_type = to_be_transferred[run]
@@ -214,13 +212,13 @@ def rsync_server_remote(hpc_server, client, to_be_transferred, run_file):
                 path=folder["input"],
                 run=run,
                 output=folder["output"],
-                bgarray=settings.bgarray,
+                bgarray=bgarray,
                 log=log,
                 errorlog=settings.errorlog,
                 temperror=temperror
             )
         )
-        rsync_result = check_rsync(run, folder_location_type, temperror, f"{settings.bgarray}/{log}")
+        rsync_result = check_rsync(run, folder_location_type, temperror, f"{bgarray}/{log}")
 
         if rsync_result == "ok":
             upload_result_gatk = None
@@ -250,9 +248,9 @@ def rsync_server_remote(hpc_server, client, to_be_transferred, run_file):
                 upload_result_exomedepth=upload_result_exomedepth
             )
             # do not include run in transferred_runs.txt if temp error file is not empty.
-            with open(f"{settings.wkdir}/transferred_runs.txt", 'a', newline='\n') as log_file:
+            with open(f"{wkdir}/transferred_runs.txt", 'a', newline='\n') as log_file:
                 log_file_writer = writer(log_file, delimiter='\t')
-                log_file_writer.writerow([f"{run}_{folder}", email_state])
+                log_file_writer.writerow([f"{run}_{folder_location_type}", email_state])
     return remove_run_file
 
 

--- a/settings.py
+++ b/settings.py
@@ -15,6 +15,8 @@ user = ""
 
 
 """Mail finished transfer"""
+email_smtp_host = "smtp-open.umcutrecht.nl"
+email_smtp_port = 25
 email_from = ""
 email_to = ["", ""]
 

--- a/test_rsync_to_rdisc.py
+++ b/test_rsync_to_rdisc.py
@@ -138,7 +138,8 @@ class TestConnectToRemoteServer():
             rsync_to_rdisc.connect_to_remote_server("host_keys", ["hpct04", "hpct05"], "user", set_up_test['run_file'])
         fake_ssh_client.load_host_keys.assert_called_once_with("host_keys")
         fake_ssh_client.load_system_host_keys.assert_called_once()
-        assert fake_ssh_client.connect.call_count <= 2 and fake_ssh_client.connect.call_count  # not 0 and max nr provided servers
+        # max nr provided servers and not 0
+        assert fake_ssh_client.connect.call_count <= 2 and fake_ssh_client.connect.call_count
 
     def test_raises_OSerror(self, mocker, set_up_test, mock_send_mail_lost_hpc, mock_sys_exit):
         fake_ssh_client = mocker.MagicMock()
@@ -213,7 +214,7 @@ class TestActionIfFileMissing():
         assert return_bool
 
     @pytest.mark.parametrize("folder,template,subject", [
-        ({"continue_without_email": False}, "transfer_notcomplete", "Analysis not complete"), 
+        ({"continue_without_email": False}, "transfer_notcomplete", "Analysis not complete"),
         ({}, "settings", "Unknown status"),
         ({"continue_without_email": "fake"}, "settings", "Unknown status")
     ])

--- a/test_rsync_to_rdisc.py
+++ b/test_rsync_to_rdisc.py
@@ -276,12 +276,13 @@ class TestUploadGatkVcf():
     def side_effect_run_vcf_upload(self, value):
         return value
 
-    @pytest.mark.parametrize("vcf_folder,expected", [
-        (set_up_test["empty_vcf_path"], 0),
-        (set_up_test["single_vcf_path"], 1),
-        (set_up_test["multi_vcf_path"], 2),
+    @pytest.mark.parametrize("vcf_folder_key,expected", [
+        ("empty_vcf_path", 0),
+        ("single_vcf_path", 1),
+        ("multi_vcf_path", 2),
     ])
-    def test_no_vcf(self, set_up_test, vcf_folder, expected, mocker):
+    def test_no_vcf(self, set_up_test, vcf_folder_key, expected, mocker):
+        vcf_folder = set_up_test[vcf_folder_key]
         mock_run_vcf_upload = mocker.patch("rsync_to_rdisc.run_vcf_upload", side_effect=self.side_effect_run_vcf_upload)
         mock_check = mocker.patch("rsync_to_rdisc.check_if_upload_successful")
         run_folder = vcf_folder.parents[1]
@@ -289,7 +290,6 @@ class TestUploadGatkVcf():
         assert len(upload_result) == expected
         assert mock_run_vcf_upload.call_count == expected
         mock_check.assert_called_once()
-
 
 
 class TestUploadExomedepthVcf():

--- a/test_rsync_to_rdisc.py
+++ b/test_rsync_to_rdisc.py
@@ -14,7 +14,7 @@ import rsync_to_rdisc
 @pytest.fixture(scope="session")
 def set_up_test(tmp_path_factory):
     """
-    Production folder structure set up is replicated with fake values.
+    Production folder structure is replicated with fake values.
     There are a few analysis of run 230920_A01131_0356_AHKM7VDRX3.
     1: everything ok.
     2: incomplete, therefore missing several files such as workflow.done

--- a/test_rsync_to_rdisc.py
+++ b/test_rsync_to_rdisc.py
@@ -261,12 +261,12 @@ def test_run_vcf_upload(mocker, set_up_test):
 
 
 @pytest.mark.parametrize("msg,expected", [
-    ("error", False),
-    ("Error", False),
-    ("vcf_upload_error", False),
-    ("ok", True)
+    (["error"], False),
+    (["Error"], False),
+    (["vcf_upload_error"], False),
+    (["ok"], True)
    ])
-def test_check_if_upload_succesful(self, msg, expected):
+def test_check_if_upload_succesful(msg, expected):
     return_bool = rsync_to_rdisc.check_if_upload_successful(msg)
     assert return_bool == expected
 

--- a/test_rsync_to_rdisc.py
+++ b/test_rsync_to_rdisc.py
@@ -140,7 +140,6 @@ class TestCheckRsync():
         assert rsync_result == "ok"
         assert not tmperror_empty.exists()
         assert "No errors detected" in bgarray_log.read_text()
-        # TODO: assert log message
 
     def test_temperror(self, mock_send_mail_transfer_state, set_up_test):
         bgarray_log = Path(f"{set_up_test['tmp_path']}/bgarray.log")

--- a/test_rsync_to_rdisc.py
+++ b/test_rsync_to_rdisc.py
@@ -280,8 +280,8 @@ def test_check_if_upload_succesful(msg, expected):
 
 
 class TestUploadGatkVcf():
-    def side_effect_run_vcf_upload(self, value):
-        return value
+    def side_effect_run_vcf_upload(self, vcf_file, vcf_type, run):
+        return [vcf_file]
 
     @pytest.mark.parametrize("vcf_folder_key,expected", [
         ("empty_vcf_path", 0),
@@ -292,10 +292,10 @@ class TestUploadGatkVcf():
         vcf_folder = set_up_test[vcf_folder_key]
         mock_run_vcf_upload = mocker.patch("rsync_to_rdisc.run_vcf_upload", side_effect=self.side_effect_run_vcf_upload)
         mock_check = mocker.patch("rsync_to_rdisc.check_if_upload_successful")
-        run_folder = vcf_folder.parents[1]
+        run_folder = vcf_folder.parent
         upload_successful, upload_result = rsync_to_rdisc.upload_gatk_vcf(run_folder.stem, run_folder)
-        assert len(upload_result) == expected
-        assert mock_run_vcf_upload.call_count == expected
+        assert len(upload_result) == expected  # nr of vcfs uploaded
+        assert mock_run_vcf_upload.call_count == expected  # run_vcf_upload is called for each vcf
         mock_check.assert_called_once()
 
 

--- a/test_rsync_to_rdisc.py
+++ b/test_rsync_to_rdisc.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python
+from pathlib import Path
+
+from paramiko import ssh_exception
+import pytest
+# from socket import timeout
+
+import rsync_to_rdisc
+
+
+@pytest.fixture
+def set_up_test(tmp_path):
+    # setup folder structure in tmpdir
+    run = "230920_A01131_0356_AHKM7VDRX3_1"
+    processed_run_dir = Path(tmp_path/f"processed/{run}")
+    processed_run_dir.mkdir(parents=True)
+    Path(tmp_path/"empty.error").touch()
+    Path(tmp_path/"tmp.error").write_text("hello")
+    Path(tmp_path/"bgarray.log").touch()
+    run_file = tmp_path/"transfer.running"
+    Path(run_file).touch()
+    Path(tmp_path/"transferred_runs.txt").write_text(run)
+    Path(tmp_path/"empty/").mkdir()
+    Path(processed_run_dir/"workflow.done").touch()
+
+    # single vcf folders
+    empty_vcf_path = Path(tmp_path/"processed/230920_A01131_0356_AHKM7VDRX3_2/single_sample_vcf/")
+    single_vcf_path = Path(tmp_path/"processed/230920_A01131_0356_AHKM7VDRX3_3/single_sample_vcf/")
+    multi_vcf_path = Path(tmp_path/"processed/230920_A01131_0356_AHKM7VDRX3_4/single_sample_vcf/")
+    empty_vcf_path.mkdir(parents=True)
+    single_vcf_path.mkdir(parents=True)
+    multi_vcf_path.mkdir(parents=True)
+    single_vcf_path.touch()
+    multi_vcf_path.touch()
+    multi_vcf_path.touch()
+
+    return {"tmp_path": tmp_path, "processed_run_dir": processed_run_dir, "run_file": run_file, "run": run,
+            "empty_vcf_path": empty_vcf_path, "single_vcf_path": single_vcf_path, "multi_vcf_path": multi_vcf_path}
+
+
+@pytest.fixture(scope="class")
+def mock_path_unlink(class_mocker):
+    return class_mocker.patch("rsync_to_rdisc.Path.unlink")
+
+
+@pytest.fixture(scope="class")
+def mock_send_mail_incomplete(class_mocker):
+    return class_mocker.patch("rsync_to_rdisc.send_mail_incomplete")
+
+
+@pytest.fixture(scope="class")
+def mock_send_mail_lost_hpc(class_mocker):
+    return class_mocker.patch("rsync_to_rdisc.send_mail_lost_hpc")
+
+
+@pytest.fixture(scope="class")
+def mock_send_mail_lost_mount(class_mocker):
+    return class_mocker.patch("rsync_to_rdisc.send_mail_lost_mount")
+
+
+@pytest.fixture(scope="class")
+def mock_send_mail_transfer_state(class_mocker):
+    return class_mocker.patch("rsync_to_rdisc.send_mail_transfer_state")
+
+
+@pytest.fixture(scope="class")
+def mock_sys_exit(class_mocker):
+    return class_mocker.patch("rsync_to_rdisc.sys.exit")
+
+
+class TestCheckRsync():
+    def test_ok(self, set_up_test, mocker):
+        bgarray_log = Path(set_up_test['tmp_path']/"bgarray.log")
+        tmperror_empty = Path(set_up_test['tmp_path']/"empty.error")
+        rsync_result = rsync_to_rdisc.check_rsync(
+            set_up_test['run'], "Exomes", tmperror_empty, bgarray_log
+        )
+        assert rsync_result == "ok"
+        assert not tmperror_empty.exists()
+        assert "No errors detected" in bgarray_log.read_text()
+
+        # assert log message
+
+    def test_temperror(self, mock_send_mail_transfer_state, set_up_test):
+        bgarray_log = Path(f"{set_up_test['tmp_path']}/bgarray.log")
+        rsync_result = rsync_to_rdisc.check_rsync(
+            set_up_test['run'], "Exomes", Path(set_up_test['tmp_path']/"tmp.error"), bgarray_log
+        )
+        assert rsync_result == "error"
+        assert f"{set_up_test['run']}_Exomes errors detected" in bgarray_log.read_text()
+        mock_send_mail_transfer_state.assert_called_once()
+
+        # Reset all mocks
+        mock_send_mail_transfer_state.reset_mock()
+
+
+class TestCheckDaemonRunning():
+    def test_new_file(self, set_up_test):
+        rsync_to_rdisc.check_daemon_running(f"{set_up_test['tmp_path']}/empty/")
+        assert Path(f"{set_up_test['tmp_path']}/empty/transfer.running").exists()
+
+    def test_file_exists(self, set_up_test, mock_sys_exit):
+        rsync_to_rdisc.check_daemon_running(set_up_test['tmp_path'])
+        mock_sys_exit.assert_called_once()
+        mock_sys_exit.reset_mock()
+
+
+class TestCheckMount():
+    def test_mount_exists(self, set_up_test, mock_send_mail_lost_mount):
+        rsync_to_rdisc.check_mount(set_up_test['tmp_path'], set_up_test['run_file'])
+        mock_send_mail_lost_mount.assert_not_called()
+
+    def test_lost_mount(self, set_up_test, mock_send_mail_lost_mount, mock_sys_exit):
+        rsync_to_rdisc.check_mount("fake_path", set_up_test['run_file'])
+        mock_send_mail_lost_mount.assert_called_once()
+        mock_sys_exit.assert_called_once()
+        # Reset mock
+        mock_send_mail_lost_mount.reset_mock()
+        mock_sys_exit.reset_mock()
+
+
+class TestGetTransferredRuns():
+    def test_get(self, set_up_test):
+        transferred_runs = rsync_to_rdisc.get_transferred_runs(set_up_test['tmp_path'])
+        assert transferred_runs == {set_up_test['run']}
+
+    def test_empty_transferred_runs(self, set_up_test, mocker):
+        mock_touch = mocker.patch("rsync_to_rdisc.Path.touch")
+        transferred_runs = rsync_to_rdisc.get_transferred_runs(f"{set_up_test['tmp_path']}/empty/")
+        assert not transferred_runs  # Empty set
+        mock_touch.assert_called_once_with(Path(f"{set_up_test['tmp_path']}/empty/transferred_runs.txt"))
+
+
+class TestConnectToRemoteServer():
+    def test_connect_ok(self, mocker, set_up_test):
+        fake_ssh_client = mocker.MagicMock()
+        with mocker.patch("rsync_to_rdisc.SSHClient", return_value=fake_ssh_client):
+            rsync_to_rdisc.connect_to_remote_server("host_keys", ["hpct04", "hpct05"], "user", set_up_test['run_file'])
+        fake_ssh_client.load_host_keys.assert_called_once_with("host_keys")
+        fake_ssh_client.load_system_host_keys.assert_called_once()
+        fake_ssh_client.connect.call_count <= 2 and fake_ssh_client.connect.call_count  # not 0 and max nr provided servers
+
+    def test_raises_OSerror(self, mocker, set_up_test, mock_send_mail_lost_hpc, mock_sys_exit):
+        fake_ssh_client = mocker.MagicMock()
+        fake_ssh_client.connect.side_effect = OSError
+        with mocker.patch("rsync_to_rdisc.SSHClient", return_value=fake_ssh_client):
+            rsync_to_rdisc.connect_to_remote_server("host_keys", ["hpct04"], "user", set_up_test['run_file'])
+        mock_send_mail_lost_hpc.assert_called_once_with("hpct04", set_up_test['run_file'])
+        mock_sys_exit.assert_called_once_with("Connection to HPC transfernodes are lost.")
+        # Reset
+        mock_send_mail_lost_hpc.reset_mock()
+        mock_sys_exit.reset_mock()
+
+    # TODO: test socket.timeout
+    @pytest.mark.parametrize("side", [ssh_exception.SSHException, ssh_exception.AuthenticationException])
+    def test_raises_errors(self, side, mocker, set_up_test, mock_path_unlink):
+        fake_ssh_client = mocker.MagicMock()
+        fake_ssh_client.connect.side_effect = side
+        with mocker.patch("rsync_to_rdisc.SSHClient", return_value=fake_ssh_client):
+            with pytest.raises(SystemExit) as system_error:
+                rsync_to_rdisc.connect_to_remote_server("host_keys", ["hpct04"], "user", set_up_test['run_file'])
+        assert system_error.type == SystemExit
+        assert str(system_error.value) == "HPC connection timeout/SSHException/AuthenticationException"
+        mock_path_unlink.assert_called_with(set_up_test['run_file'])
+
+        # Reset
+        mock_path_unlink.reset_mock()
+
+
+class TestGetFoldersRemoteServer():
+    # TODO: finish test_ok
+    def test_ok(self, set_up_test, mocker):
+        stdout = mocker.MagicMock()
+        stdout.read().decode("utf8").split.return_value = ["1", "2"]
+        client = mocker.MagicMock()
+        client.exec_command.return_value = "", stdout, ""
+        rsync_to_rdisc.get_folders_remote_server(
+            client, {"Exomes": {"input": ""}}, set_up_test['run_file'], {set_up_test['run']}
+        )
+
+    @pytest.mark.parametrize("side", [ConnectionResetError, TimeoutError])
+    def test_errors(self, side, set_up_test, mocker, mock_path_unlink):
+        client = mocker.MagicMock()
+        client.exec_command.side_effect = side
+        with pytest.raises(SystemExit) as system_error:
+            rsync_to_rdisc.get_folders_remote_server(
+                client, {"Exomes": {"input": ""}}, set_up_test['run_file'], {set_up_test['run']}
+            )
+        mock_path_unlink.assert_called_with(set_up_test['run_file'])
+        assert system_error.type == SystemExit
+        assert str(system_error.value) == "HPC connection ConnectionResetError/TimeoutError"
+
+        # Reset
+        mock_path_unlink.reset_mock()
+
+
+class TestCheckIfFileMissing():
+    @pytest.mark.parametrize("return_val,expected", [("Absent", ["workflow.done"]), ("Present", [])])
+    def test_file_available(self, return_val, expected, set_up_test, mocker):
+        stdout = mocker.MagicMock()
+        stdout.read().decode("utf8").rstrip.return_value = return_val
+        client = mocker.MagicMock()
+        client.exec_command.return_value = "", stdout, ""
+        # how to test client.exec_command?
+        missing = rsync_to_rdisc.check_if_file_missing(["workflow.done"], set_up_test['processed_run_dir'], client)
+        assert missing == expected
+
+
+class TestActionIfFileMissing():
+    def test_without_email(self, set_up_test):
+        return_bool = rsync_to_rdisc.action_if_file_missing(
+            {"continue_without_email": True}, True, "", set_up_test["run"], "Exomes", set_up_test["run_file"]
+        )
+        assert return_bool
+
+    @pytest.mark.parametrize("folder,template,subject", [
+        ({"continue_without_email": False}, "transfer_notcomplete", "Analysis not complete"), 
+        ({}, "settings", "Unknown status"),
+        ({"continue_without_email": "fake"}, "settings", "Unknown status")
+    ])
+    def test_with_email(self, folder, template, subject, set_up_test, mock_send_mail_incomplete):
+        return_bool = rsync_to_rdisc.action_if_file_missing(
+            folder, True, "", set_up_test["run"], "Exomes", set_up_test["run_file"]
+        )
+        mock_send_mail_incomplete.assert_called_once()
+        assert template == mock_send_mail_incomplete.call_args[0][1]
+        assert mock_send_mail_incomplete.call_args[0][2].startswith(subject)
+        assert not return_bool
+        mock_send_mail_incomplete.reset_mock()
+
+
+class TestRsyncServerRemote():
+    def test_missing_file(self):
+        pass
+
+    def test_rsync_ok(self):
+        pass
+
+    def test_rsync_error(self):
+        pass
+
+    # parametrize gatk/ed error and no errors.
+    def test_vcf_upload(self):
+        pass
+
+
+def test_run_vcf_upload(mocker, set_up_test):
+    stdout = mocker.MagicMock()
+    stdout.strip().split('\n').return_value = ["", "passed", "done"]
+    mock_subprocess = mocker.MagicMock()
+    # subprocess.run.return_value = "", stdout, ""
+    
+    with mocker.patch("rsync_to_rdisc.subprocess", return_value=mock_subprocess):
+        out = rsync_to_rdisc.run_vcf_upload("fake.vcf", 'VCF_FILE', set_up_test["run"])
+
+    print(mock_subprocess.call_args_list)
+    mock_subprocess.run.assert_called_once()
+    command = mock_subprocess.run.call_args[0][1]
+    required_strs = ["activate", "vcf_upload.py", "fake.vcf", 'VCF_FILE', set_up_test["run"]]
+    assert all([required_str in command for required_str in required_strs])
+    assert out == ["passed", "done"]
+
+
+@pytest.mark.parametrize("msg,expected", [
+    ("error", False),
+    ("Error", False),
+    ("vcf_upload_error", False),
+    ("ok", True)
+   ])
+def test_check_if_upload_succesful(self, msg, expected):
+    return_bool = rsync_to_rdisc.check_if_upload_successful(msg)
+    assert return_bool == expected
+
+
+class TestUploadGatkVcf():
+    def side_effect_run_vcf_upload(self, value):
+        return value
+
+    @pytest.mark.parametrize("vcf_folder,expected", [
+        (set_up_test["empty_vcf_path"], 0),
+        (set_up_test["single_vcf_path"], 1),
+        (set_up_test["multi_vcf_path"], 2),
+    ])
+    def test_no_vcf(self, set_up_test, vcf_folder, expected, mocker):
+        mock_run_vcf_upload = mocker.patch("rsync_to_rdisc.run_vcf_upload", side_effect=self.side_effect_run_vcf_upload)
+        mock_check = mocker.patch("rsync_to_rdisc.check_if_upload_successful")
+        run_folder = vcf_folder.parents[1]
+        upload_successful, upload_result = rsync_to_rdisc.upload_gatk_vcf(run_folder.stem, run_folder)
+        assert len(upload_result) == expected
+        assert mock_run_vcf_upload.call_count == expected
+        mock_check.assert_called_once()
+
+
+
+class TestUploadExomedepthVcf():
+    pass

--- a/test_rsync_to_rdisc.py
+++ b/test_rsync_to_rdisc.py
@@ -228,15 +228,15 @@ class TestConnectToRemoteServer():
 
 
 class TestGetFoldersRemoteServer():
-    # TODO: finish test_ok
     def test_ok(self, set_up_test, mocker):
         stdout = mocker.MagicMock()
-        stdout.read().decode("utf8").split.return_value = ["1", "2"]
+        stdout.read().decode("utf8").split.return_value = ["analysis1", "analysis2"]
         client = mocker.MagicMock()
         client.exec_command.return_value = "", stdout, ""
-        rsync_to_rdisc.get_folders_remote_server(
+        to_transfer = rsync_to_rdisc.get_folders_remote_server(
             client, {"Exomes": {"input": ""}}, set_up_test['run_file'], {set_up_test['analysis1']}
         )
+        assert to_transfer == {'analysis1': 'Exomes', 'analysis2': 'Exomes'}
 
     @pytest.mark.parametrize("side", [ConnectionResetError, TimeoutError])
     def test_errors(self, side, set_up_test, mocker, mock_path_unlink):


### PR DESCRIPTION
## What has changed?
- Add error state to transferred_runs.txt, so it can be used in other processes such as DxAutomation, including pytest. Therefore refactor of functions `rsync_and_check` and `rsync_server_remote`
- use csv writer to write txt to a file.
- Refactor of make_mail: use redmail and create functions per scenario (previously separated by if-elif-else)
- Pathlib and os were used; for consistency I replaced os commands with Pathlib.
- Changed several functions or its input args to be able to use pytest easily.
- A few local variables didnot exist, resolved.
- requirements.txt: added dev (unit test related packages) and prod (required to run tool) settings


## Remarks
- github actions workflow (to enable automatic pytest) can be configured once the `.github/workflows/rsync_to_rdisc.yml` is merged into dev. Results of local pytest run:
  ```
  38 passed, 4 warnings in 0.55s
  
  Name                     Stmts   Miss  Cover
  --------------------------------------------
  rsync_to_rdisc.py          207     33    84%
  ```

- tests in TestConnectToRemoteServer all raise a warning, because I am using the `with mocker.patch` statement. I was unable to create a pytest without the `with` statement and just using a patched variable for the SSHClient object. Please inform me if you know a solution. 
A `# TODO` comment is added to these lines. 
```PytestMockWarning: Mocks returned by pytest-mock do not need to be used as context managers. The mocker fixture automatically undoes mocking at the end of a test. This warning can be ignored if it was triggered by mocking a context manager. https://pytest-mock.readthedocs.io/en/latest/remarks.html#usage-as-context-manager```


- set_up_test has scope session and is thus executed once (using tmp_path_factory instead of tmp_path). I think it would be better if set_up_test is split into multiple fixtures, for example one for 
    - get_tmp_path
    - single_sample_vcf
    - exomedepth / cnv
    - files required to start/stop running of rsync_to_rdisc 
    
    I would suggest to resolve this in the future and not part of this PR :)