### PR TITLE
rename branches in github workflows (to master)

### DIFF
--- a/.github/workflows/rsync_to_rdisc.yml
+++ b/.github/workflows/rsync_to_rdisc.yml
@@ -6,12 +6,12 @@ name: rsync_to_rdisc
 on:
   push:
     branches:
-      - main
-      - develop
+      - master
+      - development
   pull_request:
     branches:
-      - main
-      - develop
+      - master
+      - development
 
 jobs:
   build:

--- a/.github/workflows/rsync_to_rdisc.yml
+++ b/.github/workflows/rsync_to_rdisc.yml
@@ -33,7 +33,6 @@ jobs:
         python -m pip install --upgrade pip
         # use dev requirements including pytest and flake8
         if [ -f requirements/dev.txt ]; then pip install -r requirements/dev.txt; fi  
-        pip install -e .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,7 @@
 # Mirror production requirements
 -r prod.txt
 # Add dev specific packages
+flake8==3.7.3
 pytest==7.0.1
 pytest-cov==4.0.0
 pytest-mock==3.6.1


### PR DESCRIPTION
Rename branches to enable github workflow actions for automatic unit tests.